### PR TITLE
civilianData arrayı içinde aynı civillianImageUrl kullanılmasını önler ve test içinde rastgele siviller oluşturur

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,10 +168,10 @@
 
   async function fetchCivilianData() {
     try {
-      const civilianImageUrl = 'https://thispersondoesnotexist.com/';
       const civilianData = [];
-
       for (let i = 0; i < 750; i++) {
+        const timestamp = new Date().getTime();
+        const civilianImageUrl = `https://thispersondoesnotexist.com/?timestamp=${timestamp}`;
         civilianData.push({
           TOrgutAdi: 'Sivil',
           IlkGorselURL: civilianImageUrl


### PR DESCRIPTION
thispersondoesnotexist.com sitesinin çalışma prensibi yüzünden uygulamada tüm görseller ilk başta fetch edilen thispersondoesnotexist.com url'si üzerinden çekiliyor. 

Bu durum test içindeki tüm sivillerin görselinin aynı olması gibi bir bug ortaya çıkarıyor. Bunu düzeltmek için civilianImageUrl döngünün içerisine çekildi ve farklı sonuçlar alınması için sonuna timestamp parametresi eklendi.

POC: https://imgur.com/a/2BvFtfz